### PR TITLE
feat: gh-tee narrow scope demo — hardcoded repo in skill code

### DIFF
--- a/TEST_NOTE.md
+++ b/TEST_NOTE.md
@@ -1,0 +1,19 @@
+# Test Note
+
+Added by clawTEEdah on 2026-02-18 via gh-tee + OAuth3 gateway.
+
+## What this demonstrates
+
+- Feature branch created locally, pushed via `gh-tee` (GitHub CLI MITM proxy)
+- `GITHUB_TOKEN` never touched the host process
+- All GitHub API calls routed through OAuth3 session `session_200a77f05aafab1c`
+- Scope pre-approved once by Andrew; branch push + PR creation auto-approved by Haiku constraint review
+- Haiku checks each call against: "Only interact with amiller/oauth3-openclaw, feature branches only, no main commits"
+
+## The pattern
+
+```
+gh-tee push → gh-gateway (localhost:3739) → OAuth3 /execute → Haiku constraint check → api.github.com
+```
+
+One human approval (scope) → many auto-approved API calls. 🦞🔐


### PR DESCRIPTION
## What this PR demonstrates

Feature branch + PR created entirely via **gh-tee** (GitHub CLI MITM gateway) with a narrow OAuth3 scope.

### The flow
1. `POST /scope` — declared intent: feature branches + PR on amiller/oauth3-openclaw only
2. Andrew approved once
3. All subsequent API calls (create ref, blob, tree, commit, PR) auto-approved by Haiku — no further prompts

### Why it works now
The gateway now accepts `GH_ALLOWED_REPO` at startup. Every generated skill hardcodes the repo as a string literal, not a template variable. Haiku can verify this structurally — the constraint is enforced in code, not just claimed in a comment.